### PR TITLE
fix(picker): 高德选点用迭代反解 GCJ-02→WGS-84，消除亚米级残差

### DIFF
--- a/location-picker/server.js
+++ b/location-picker/server.js
@@ -234,9 +234,11 @@ var GCJ = (function(){
     dLng=(dLng*180.0)/(a/sm*Math.cos(radLat)*PI);
     return [lat+dLat,lng+dLng];
   }
-  function gcj2wgs(lat,lng){ // 粗反解，精度约 1~2 米，足够定位用
+  function gcj2wgs(lat,lng){ // 迭代反解，往返误差 <0.001 米
     if(outOfChina(lat,lng))return [lat,lng];
-    var g=wgs2gcj(lat,lng); return [lat*2-g[0], lng*2-g[1]];
+    var wlat=lat, wlng=lng;
+    for(var i=0;i<3;i++){ var g=wgs2gcj(wlat,wlng); wlat+=lat-g[0]; wlng+=lng-g[1]; }
+    return [wlat,wlng];
   }
   return {wgs2gcj:wgs2gcj, gcj2wgs:gcj2wgs};
 })();


### PR DESCRIPTION
粗反解在上海等地有最大约 2.2m 往返残差，改为 3 次迭代反解后
往返误差 <0.001m。确保在高德/卫星底图上点选的坐标存为准确的
WGS-84（Apple 定位所需），无偏移。