### PR TITLE
fix(#13): 区分 missing token (401) 与 bad token (403); docs: ?token= 必传说明 + Apple News FAQ (#11)

### DIFF
--- a/location-picker/server.js
+++ b/location-picker/server.js
@@ -15,6 +15,9 @@
 //
 // Shadowrocket 模块 argument 末尾加：
 //   &configUrl=https://你的域名:8443/loc.json?token=你的密码
+//
+// 注意：URL 必须带 ?token=<TOKEN>。缺 token → 服务端返回 401 + "missing token"；
+// token 错 → 返回 403 + "bad token"。网页端点同样适用。
 
 const http = require("http");
 const https = require("https");
@@ -58,23 +61,33 @@ function send(res, code, type, body) {
   res.end(body);
 }
 
+// 区分「没传 token」和「token 传错」：前者 401 引导补 ?token=，后者 403
+function checkToken(token, res) {
+  if (!TOKEN) return true; // 没设 TOKEN 环境变量 = 不校验（仅本地开发用）
+  if (token == null || token === "") {
+    send(res, 401, "application/json", '{"error":"missing token","hint":"add ?token=<TOKEN> to the URL (must match the TOKEN env var)"}');
+    return false;
+  }
+  if (token !== TOKEN) {
+    send(res, 403, "application/json", '{"error":"bad token"}');
+    return false;
+  }
+  return true;
+}
+
 function handler(req, res) {
   const url = new URL(req.url, "http://" + (req.headers.host || "localhost"));
   const token = url.searchParams.get("token");
 
   // ---- Shadowrocket 读取坐标（存的就是 WGS-84，Apple 需要的格式） ----
   if (url.pathname === "/loc.json" && req.method === "GET") {
-    if (TOKEN && token !== TOKEN) {
-      return send(res, 403, "application/json", '{"error":"bad token"}');
-    }
+    if (!checkToken(token, res)) return;
     return send(res, 200, "application/json", JSON.stringify(readLoc()));
   }
 
   // ---- 网页保存（前端已转好 WGS-84 再发过来；海拔/精度可选） ----
   if (url.pathname === "/set" && req.method === "POST") {
-    if (TOKEN && token !== TOKEN) {
-      return send(res, 403, "application/json", '{"error":"bad token"}');
-    }
+    if (!checkToken(token, res)) return;
     let body = "";
     req.on("data", function (c) {
       body += c;
@@ -115,9 +128,7 @@ function handler(req, res) {
 
   // ---- 一键切换：伪造 / 恢复真实定位 ----
   if (url.pathname === "/enable" && req.method === "POST") {
-    if (TOKEN && token !== TOKEN) {
-      return send(res, 403, "application/json", '{"error":"bad token"}');
-    }
+    if (!checkToken(token, res)) return;
     let body = "";
     req.on("data", function (c) {
       body += c;

--- a/使用教程.md
+++ b/使用教程.md
@@ -207,6 +207,12 @@ node server.js
 &configUrl=https://example.com:8443/loc.json?token=上面那个TOKEN
 ```
 
+> ⚠️ **URL 末尾必须带 `?token=<TOKEN>`**，且这个 TOKEN 必须和服务器启动时环境变量 `TOKEN` 的值完全一致。否则：
+> - 没带 `?token=` → 服务端返回 **401** `missing token`
+> - `?token=` 写错 → 服务端返回 **403** `bad token`
+>
+> 同样的规则适用于浏览器访问 `/`、`/set`、`/enable` 端点。
+
 数据文件 `loc.json` 自动落在 `server.js` 同目录，记录当前坐标 / 海拔 / 精度；已写入 `.gitignore`，不会污染仓库。
 
 > ⚠️ **不要把 `TOKEN` 直接写在命令行里**——推荐用 systemd 的 `Environment=` 或 `.env` + `direnv`，避免 `history` 和 `ps aux` 泄露出去。
@@ -233,6 +239,9 @@ node server.js
 
 **Q：可以恢复真实定位吗？**
 可以。关掉模块（取消 ✓）或关掉 Shadowrocket 总开关，然后按第六步刷新一次定位即可恢复。
+
+**Q：Apple News / 依赖区域的服务还是判定我在原位置？**
+Apple News 等部分应用不只读定位，还依赖 iOS 系统服务的多个开关。请打开 **设置 → 隐私与安全性 → 定位服务 → 系统服务**，把里面所有开关全部打开（特别是「基于位置的 Apple 广告」「重要地点」「iPhone 分析」「路由与流量」「提升地图准确性」等）。全部打开后再关开一次定位，Apple News 通常就能识别到新区域了。
 
 ---
 


### PR DESCRIPTION
## 修复内容

### location-picker/server.js — 区分 401 / 403 (#13)
新增 `checkToken()` 辅助函数，三个端点统一调用：
- 缺 `?token=` → **401** `missing token`（带 hint 提示怎么补）
- `?token=` 写错 → **403** `bad token`（行为不变）
- `TOKEN` 环境变量未设时跳过校验（保留本地开发体验）

之前所有失败都返 403 + `bad token`，用户根本看不出来是没带 token 还是 token 写错，调试非常痛苦。

### 使用教程.md — 文档补全
1. 第七节「自托管 location-picker」补充 `?token=` 必传说明 + 401/403 错误码对照
2. FAQ 新增「Apple News / 依赖区域的服务还是判定原位置？」条目，把 #11 解决链路（**设置 → 隐私与安全性 → 定位服务 → 系统服务** 全部打开）写进去

## 关联 issue
- Closes #13
- Closes #11（FAQ 已记录解决方案）

## 验证
- `git diff --check`：clean
- `checkToken()` 逻辑单元测试：未设 TOKEN → 通过；缺 token → 401；token 错 → 403；token 对 → 通过

## 影响面
- **后端 API 行为变更**：缺 token 由 403 改为 401。语义更准确但有 breaking change，下游脚本若依赖原 403 状态码需相应调整（仓库内无此类脚本依赖）。
- 文档纯增量，无 breaking。

ai自动回复