### PR TITLE
fix(picker): normalize wrapped longitudes

### DIFF
--- a/location-picker/worker/src/index.js
+++ b/location-picker/worker/src/index.js
@@ -86,6 +86,10 @@ function setInt(target, key, value) {
   }
 }
 
+function wrapLng(lng) {
+  return ((((Number(lng) + 180) % 360) + 360) % 360) - 180;
+}
+
 export default {
   async fetch(request, env) {
     if (request.method === "OPTIONS") {
@@ -115,10 +119,11 @@ export default {
         }
         const j = JSON.parse(bodyText);
         const la = Number(j.lat);
-        const lo = Number(j.lng);
-        if (!Number.isFinite(la) || !Number.isFinite(lo) || la < -90 || la > 90 || lo < -180 || lo > 180) {
+        const loRaw = Number(j.lng);
+        if (!Number.isFinite(la) || !Number.isFinite(loRaw) || la < -90 || la > 90) {
           return jsonResponse({ error: "bad coords" }, 400);
         }
+        const lo = wrapLng(loRaw);
         const cur = await readLoc(env);
         cur.latitude = la;
         cur.longitude = lo;

--- a/location-picker/worker/src/page.js
+++ b/location-picker/worker/src/page.js
@@ -85,6 +85,8 @@ var saved = true;
 function $(id){return document.getElementById(id);}
 function toast(t){var e=$("toast");e.textContent=t;e.classList.add("show");setTimeout(function(){e.classList.remove("show");},1800);}
 function numOrNull(id){var v=$(id).value.trim();return v===""?null:Number(v);}
+// Leaflet 在重复世界地图上可能返回 -239 这类经度，需要归一化。
+function wrapLng(lng){return ((((Number(lng)+180)%360)+360)%360)-180;}
 
 function info(){
   var tag = saved ? "已保存 ✓" : "未保存 · 点“保存定位”生效";
@@ -93,9 +95,10 @@ function info(){
 }
 
 function dispPos(){return datum==="gcj"?GCJ.wgs2gcj(WGS.lat,WGS.lng):[WGS.lat,WGS.lng];}
-function toWgs(lat,lng){return datum==="gcj"?GCJ.gcj2wgs(lat,lng):[lat,lng];}
+function toWgs(lat,lng){lng=wrapLng(lng);return datum==="gcj"?GCJ.gcj2wgs(lat,lng):[lat,lng];}
 
 function fetchElevation(lat,lng){
+  lng=wrapLng(lng);
   return fetch("https://api.open-meteo.com/v1/elevation?latitude="+lat+"&longitude="+lng)
     .then(function(r){return r.json();})
     .then(function(d){return (d&&d.elevation&&d.elevation.length)?d.elevation[0]:null;})
@@ -103,8 +106,9 @@ function fetchElevation(lat,lng){
 }
 
 function movePin(dispLat,dispLng){
+  dispLng=wrapLng(dispLng);
   var w=toWgs(dispLat,dispLng);
-  WGS={lat:w[0], lng:w[1]};
+  WGS={lat:w[0], lng:wrapLng(w[1])};
   saved=false;
   marker.setLatLng([dispLat,dispLng]);
   info();


### PR DESCRIPTION
## Summary
- Normalize wrapped longitudes from Leaflet before elevation lookup and saving picker coordinates
- Normalize longitude again in the Worker `/set` endpoint as a defensive fallback

## Why
When using repeated world map tiles, Leaflet can emit wrapped longitudes such as `-239.x`.
This is equivalent to a valid longitude like `120.x`, but the elevation API and Worker validation reject it as out of range.
This is easier to hit with the default China/Gaode map layer.

## Test
- `npm install`
- `npx wrangler deploy --dry-run`
- Verified `wrapLng(-239.61497068405154)` returns `120.38502931594849`
