### PR TITLE
Harden picker Worker (CSP, SRI, no-referrer) and lower Loon cron to */15

### DIFF
--- a/ios-location-spoofer.lnplugin
+++ b/ios-location-spoofer.lnplugin
@@ -10,7 +10,7 @@ enabled = switch,true,tag=启用定位修改,desc=关闭后脚本直接放行原
 latitude = input,"37.3349",tag=纬度(备用),desc=未配置远程时生效
 longitude = input,"-122.00902",tag=经度(备用),desc=未配置远程时生效
 altitude = input,"530",tag=海拔(米),desc=目标海拔
-address = input,"",tag=地址搜索,desc=填地名；cron 每5分钟联网解析
+address = input,"",tag=地址搜索,desc=填地名；cron 每15分钟联网解析
 configHost = input,"https://loc.ikun.day",tag=配置服务器,desc=不要末尾斜杠
 configToken = input,"",tag=配置Token,desc=必填才能读 loc.json（与 configUrl 二选一）
 configUrl = input,"",tag=远程配置URL,desc=完整 loc.json 地址；与上两项二选一
@@ -19,7 +19,7 @@ debug = switch,true,tag=调试日志,desc=建议开启，Loon 日志搜 Location
 [Script]
 http-request ^https?:\/\/(?:gs-loc(?:-cn)?\.apple\.com|bluedot\.is\.autonavi\.com(?:\.gds\.alibabadns\.com)?)\/clls\/wloc(?:\?.*)?$ script-path=https://raw.githubusercontent.com/kun775/ios-location-spoofer/main/location-spoofer.js, requires-body=false, timeout=3, tag=iOS Location Spoofer Prepare, argument=[{debug}]
 http-response ^https?:\/\/(?:gs-loc(?:-cn)?\.apple\.com|bluedot\.is\.autonavi\.com(?:\.gds\.alibabadns\.com)?)\/clls\/wloc(?:\?.*)?$ script-path=https://raw.githubusercontent.com/kun775/ios-location-spoofer/main/location-spoofer.js, requires-body=true, binary-body-mode=true, max-size=1048576, timeout=12, tag=iOS Location Spoofer, argument=[{enabled},{latitude},{longitude},{altitude},{address},{configHost},{configToken},{configUrl},{debug}]
-cron "*/5 * * * *" script-path=https://raw.githubusercontent.com/kun775/ios-location-spoofer/main/location-spoofer.js, timeout=30, tag=iOS Location Spoofer Sync, argument=[{address},{configHost},{configToken},{configUrl},{debug}]
+cron "*/15 * * * *" script-path=https://raw.githubusercontent.com/kun775/ios-location-spoofer/main/location-spoofer.js, timeout=30, tag=iOS Location Spoofer Sync, argument=[{address},{configHost},{configToken},{configUrl},{debug}]
 
 [mitm]
 hostname = gs-loc.apple.com, gs-loc-cn.apple.com, bluedot.is.autonavi.com, bluedot.is.autonavi.com.gds.alibabadns.com

--- a/location-picker/worker/src/index.js
+++ b/location-picker/worker/src/index.js
@@ -24,7 +24,24 @@ const CORS = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type",
+  // 选点页 URL 带 ?token=，务必阻止它经 Referer 泄漏给 unpkg / 高德 / OSM / open-meteo / nominatim
+  "Referrer-Policy": "no-referrer",
+  "X-Content-Type-Options": "nosniff",
 };
+
+// 选点页专属 CSP：页面 URL 带 token，锁死脚本来源与可连接域名做纵深防御，
+// 万一 CDN 被投毒也无法把 token 外传。script/style 需 'unsafe-inline'（页面自身内联），
+// 外部脚本只放行 unpkg（已配 SRI）；connect 只放行地图/地理编码接口。
+const PAGE_CSP = [
+  "default-src 'none'",
+  "script-src https://unpkg.com 'unsafe-inline'",
+  "style-src https://unpkg.com 'unsafe-inline'",
+  "img-src 'self' https: data:", // 地图瓦片（高德 wprd0*/webst0*、OSM 多子域）
+  "connect-src 'self' https://api.open-meteo.com https://nominatim.openstreetmap.org",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+].join("; ");
 
 function jsonResponse(body, status = 200) {
   return new Response(typeof body === "string" ? body : JSON.stringify(body), {
@@ -179,11 +196,23 @@ export default {
       if (!auth.ok) {
         return unauthorized();
       }
-      return textResponse(PAGE, "text/html; charset=utf-8");
+      return new Response(PAGE, {
+        headers: {
+          "Content-Type": "text/html; charset=utf-8",
+          "Cache-Control": "no-store",
+          "Content-Security-Policy": PAGE_CSP,
+          ...CORS,
+        },
+      });
     }
 
     if (url.pathname === "/health") {
       return jsonResponse({ ok: true, kv: !!env.LOC_KV, tokenConfigured: !!env.TOKEN });
+    }
+
+    // 浏览器会自动请求 favicon；这里静默返 204，避免落到 404 分支产生噪音日志
+    if (url.pathname === "/favicon.ico") {
+      return new Response(null, { status: 204, headers: CORS });
     }
 
     return textResponse("not found", "text/plain", 404);

--- a/location-picker/worker/src/page.js
+++ b/location-picker/worker/src/page.js
@@ -5,7 +5,7 @@ export const PAGE = `<!doctype html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 <title>定位选点</title>
-<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha384-sHL9NAb7lN7rfvG5lfHpm643Xkcjzp4jFvuavGOndn6pjVqS6ny56CAt3nsEVT4H" crossorigin="anonymous">
 <style>
   html,body{margin:0;height:100%;font-family:-apple-system,BlinkMacSystemFont,sans-serif}
   .bar{padding:8px;display:flex;gap:6px;box-sizing:border-box}
@@ -45,7 +45,7 @@ export const PAGE = `<!doctype html>
   <button id="restorebtn">恢复真实定位</button>
 </div>
 <div class="toast" id="toast"></div>
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script>
 <script>
 var token = new URLSearchParams(location.search).get("token") || "";
 


### PR DESCRIPTION
## What

Two small, independent hardening changes:

### 1. Picker Worker security headers + SRI (`location-picker/worker/`)

The picker page is authenticated by a token carried in the URL (`/?token=…`),
so anything that can observe the page URL or run script in the page can steal
the token. This adds defense-in-depth:

- **`Referrer-Policy: no-referrer` + `X-Content-Type-Options: nosniff`** on
  every response, so the `?token=` in the page URL is never leaked via the
  `Referer` header to unpkg / AMap / OSM / open-meteo / nominatim.
- **A locked-down `Content-Security-Policy`** on the picker page:
  `default-src 'none'`, external script/style limited to `unpkg.com`,
  `connect-src` limited to the map/geocode endpoints the page actually calls.
- **Subresource Integrity (`integrity` sha384 + `crossorigin`)** on both
  Leaflet CDN tags. If unpkg is ever compromised, the tampered payload won't
  execute, so it can't read the token out of the URL. Hashes verified against
  `unpkg.com/leaflet@1.9.4/dist/leaflet.{css,js}`.
- **`/favicon.ico` → `204`** so the browser's automatic favicon request stops
  falling through to the 404 branch.

The CSP was validated against the exact resources the page loads (unpkg
Leaflet, AMap/OSM tiles, open-meteo elevation, nominatim search,
`/loc.json` `/set` `/enable`).

### 2. Lower the Loon geocode cron from `*/5` to `*/15` (`ios-location-spoofer.lnplugin`)

The geocode sync cron ran **every 5 minutes**, which trips Loon's
*"runs too frequently / high standby power consumption"* warning. It also
contradicted the README, which documents the address-search cron as running
**every 15 minutes**. Lowering it to `*/15` matches the docs and cuts
unnecessary standby wakeups. The plugin arg description was updated to match.

## Why

Both are low-risk, self-contained. No behavior change for correct clients:
the CSP/SRI only block tampered/cross-origin resources, and the cron still
refreshes the geocode cache (just at the documented cadence).

## Testing

- `node --check` passes on the edited `index.js` / `page.js`.
- CSP + SRI combination is running in production on a self-hosted fork of
  this Worker; the map, tile layers, search, and elevation lookup all work
  under this exact policy.
