### PR TITLE
fix: fix stash config name

### DIFF
--- a/ios-location-spoofer.stoverride
+++ b/ios-location-spoofer.stoverride
@@ -1,6 +1,6 @@
-#!name=iOS Location Spoofer
-#!desc=劫持 Apple 定位封包，把坐标换成你想要的。Stash 覆写版。
-#!homepage=https://github.com/mekos2772/ios-location-spoofer
+name: iOS Location Spoofer
+desc: 劫持 Apple 定位封包，把坐标换成你想要的。Stash 覆写版。
+homepage: https://github.com/mekos2772/ios-location-spoofer
 #
 # 两种 script-providers 用法，按需选择其一启用。不要两个同时启用。
 #


### PR DESCRIPTION
stash stoverride 的 name 不是通过注释声明的，而是 yaml 的字段

before:
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/9847f596-a0fe-4f4b-98a9-d4472dfed59e" />

after:
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/0c58c785-1936-466a-a213-0a52fbca122f" />
