### PR TITLE
feat(picker,loon): favorites + editable accuracy

### DIFF
--- a/ios-location-spoofer.lnplugin
+++ b/ios-location-spoofer.lnplugin
@@ -1,15 +1,17 @@
 #!name=iOS Location Spoofer
 #!desc=拦截 Apple 定位服务回传的坐标并置换为指定位置（Loon 插件）
-#!homepage=https://github.com/kun775/ios-location-spoofer
+#!homepage=https://github.com/mekos2772/ios-location-spoofer
 
 # Loon 插件参数必须用 argument=[{参数名},...] 格式，字符串 {latitude} 占位符不会生效
-# 插件 UI 里的经纬度是备用值；填 configHost+configToken 后以 loc.json 为准（UI 不会变）
+# 插件 UI 里的经纬度/精度是备用值；填 configHost+configToken 后以 loc.json 为准（UI 不会变）
 
 [Argument]
 enabled = switch,true,tag=启用定位修改,desc=关闭后脚本直接放行原始定位数据
 latitude = input,"37.3349",tag=纬度(备用),desc=未配置远程时生效
 longitude = input,"-122.00902",tag=经度(备用),desc=未配置远程时生效
 altitude = input,"530",tag=海拔(米),desc=目标海拔
+horizontalAccuracy = input,"39",tag=水平精度(米),desc=越小越像 GPS；网页选点时以 loc.json 为准
+verticalAccuracy = input,"1000",tag=垂直精度(米),desc=配真实海拔后可调小；网页选点时以 loc.json 为准
 address = input,"",tag=地址搜索,desc=填地名；cron 每15分钟联网解析
 configHost = input,"https://loc.ikun.day",tag=配置服务器,desc=不要末尾斜杠
 configToken = input,"",tag=配置Token,desc=必填才能读 loc.json（与 configUrl 二选一）
@@ -17,9 +19,9 @@ configUrl = input,"",tag=远程配置URL,desc=完整 loc.json 地址；与上两
 debug = switch,true,tag=调试日志,desc=建议开启，Loon 日志搜 Location spoofer
 
 [Script]
-http-request ^https?:\/\/(?:gs-loc(?:-cn)?\.apple\.com|bluedot\.is\.autonavi\.com(?:\.gds\.alibabadns\.com)?)\/clls\/wloc(?:\?.*)?$ script-path=https://raw.githubusercontent.com/kun775/ios-location-spoofer/main/location-spoofer.js, requires-body=false, timeout=3, tag=iOS Location Spoofer Prepare, argument=[{debug}]
-http-response ^https?:\/\/(?:gs-loc(?:-cn)?\.apple\.com|bluedot\.is\.autonavi\.com(?:\.gds\.alibabadns\.com)?)\/clls\/wloc(?:\?.*)?$ script-path=https://raw.githubusercontent.com/kun775/ios-location-spoofer/main/location-spoofer.js, requires-body=true, binary-body-mode=true, max-size=1048576, timeout=12, tag=iOS Location Spoofer, argument=[{enabled},{latitude},{longitude},{altitude},{address},{configHost},{configToken},{configUrl},{debug}]
-cron "*/15 * * * *" script-path=https://raw.githubusercontent.com/kun775/ios-location-spoofer/main/location-spoofer.js, timeout=30, tag=iOS Location Spoofer Sync, argument=[{address},{configHost},{configToken},{configUrl},{debug}]
+http-request ^https?:\/\/(?:gs-loc(?:-cn)?\.apple\.com|bluedot\.is\.autonavi\.com(?:\.gds\.alibabadns\.com)?)\/clls\/wloc(?:\?.*)?$ script-path=https://raw.githubusercontent.com/mekos2772/ios-location-spoofer/main/location-spoofer.js, requires-body=false, timeout=3, tag=iOS Location Spoofer Prepare, argument=[{debug}]
+http-response ^https?:\/\/(?:gs-loc(?:-cn)?\.apple\.com|bluedot\.is\.autonavi\.com(?:\.gds\.alibabadns\.com)?)\/clls\/wloc(?:\?.*)?$ script-path=https://raw.githubusercontent.com/mekos2772/ios-location-spoofer/main/location-spoofer.js, requires-body=true, binary-body-mode=true, max-size=1048576, timeout=12, tag=iOS Location Spoofer, argument=[{enabled},{latitude},{longitude},{altitude},{horizontalAccuracy},{verticalAccuracy},{address},{configHost},{configToken},{configUrl},{debug}]
+cron "*/15 * * * *" script-path=https://raw.githubusercontent.com/mekos2772/ios-location-spoofer/main/location-spoofer.js, timeout=30, tag=iOS Location Spoofer Sync, argument=[{address},{configHost},{configToken},{configUrl},{debug}]
 
 [mitm]
 hostname = gs-loc.apple.com, gs-loc-cn.apple.com, bluedot.is.autonavi.com, bluedot.is.autonavi.com.gds.alibabadns.com

--- a/location-picker/cloudflare-webui/worker.js
+++ b/location-picker/cloudflare-webui/worker.js
@@ -17,9 +17,11 @@ export const PAGE = `<!doctype html>
   .bar button:disabled{opacity:.55}
   .results{margin:0 8px;border:1px solid #e2e2e2;border-radius:8px;max-height:34vh;overflow:auto;display:none}
   .results.show{display:block}
-  .rrow{padding:10px 12px;font-size:14px;border-bottom:1px solid #eee;color:#222}
+  .rrow{padding:10px 12px;font-size:14px;border-bottom:1px solid #eee;color:#222;display:flex;align-items:center;gap:8px}
   .rrow:last-child{border-bottom:0}
   .rrow:active{background:#f0f6ff}
+  .rrow .fname{flex:1;min-width:0}
+  .rrow .fdel{padding:6px 10px;font-size:13px;border:0;border-radius:6px;background:#ff3b30;color:#fff;flex-shrink:0}
   #map{height:52vh}
   #info{padding:8px 10px;font-size:13px;line-height:1.4}
   .opts{padding:6px 10px 12px;display:flex;flex-wrap:wrap;gap:8px;align-items:flex-end}
@@ -27,6 +29,7 @@ export const PAGE = `<!doctype html>
   .opts input{width:88px;padding:8px;font-size:15px;border:1px solid #ccc;border-radius:6px;margin-top:2px}
   #savebtn{padding:11px 20px;font-size:16px;border:0;border-radius:8px;background:#34c759;color:#fff;font-weight:600}
   #restorebtn{padding:11px 16px;font-size:15px;border:0;border-radius:8px;background:#8e8e93;color:#fff}
+  #favadd,#favlistbtn{padding:11px 14px;font-size:15px;border:0;border-radius:8px;background:#5856d6;color:#fff}
   .toast{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);
     background:rgba(0,0,0,.85);color:#fff;padding:10px 16px;border-radius:8px;
     font-size:14px;opacity:0;transition:opacity .3s;pointer-events:none;z-index:9999}
@@ -48,7 +51,10 @@ export const PAGE = `<!doctype html>
   <label>垂直精度<input id="vacc" type="number" inputmode="numeric"></label>
   <button id="savebtn">保存定位</button>
   <button id="restorebtn">恢复真实定位</button>
+  <button id="favadd">收藏此点</button>
+  <button id="favlistbtn">我的收藏</button>
 </div>
+<div class="results" id="favs"></div>
 <div class="toast" id="toast"></div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
@@ -109,6 +115,95 @@ function geolocationErrorMessage(err){
   if(err&&err.code===2)return "暂时无法获取当前位置";
   if(err&&err.code===3)return "获取当前位置超时，请到开阔处重试";
   return "获取当前位置失败";
+}
+
+var FAV_KEY="lp_favs_v1";
+var FAV_MAX=12;
+function loadFavs(){
+  try{
+    var raw=localStorage.getItem(FAV_KEY);
+    var a=raw?JSON.parse(raw):[];
+    return Array.isArray(a)?a:[];
+  }catch(e){return [];}
+}
+function saveFavs(list){
+  try{localStorage.setItem(FAV_KEY,JSON.stringify(list.slice(0,FAV_MAX)));}catch(e){}
+}
+function applyFavorite(it){
+  var lat=Number(it.lat), lng=wrapLng(it.lng);
+  if(!Number.isFinite(lat)||!Number.isFinite(lng)){toast("收藏坐标无效");return;}
+  WGS={lat:lat,lng:lng};
+  saved=false;
+  if(it.alt!=null&&it.alt!=="")$("alt").value=it.alt;
+  if(it.hacc!=null&&it.hacc!=="")$("hacc").value=it.hacc;
+  if(it.vacc!=null&&it.vacc!=="")$("vacc").value=it.vacc;
+  var p=dispPos();
+  marker.setLatLng(p);
+  map.setView(p,15);
+  info();
+  toast("已加载收藏，确认后保存");
+}
+function renderFavs(){
+  var box=$("favs");
+  var list=loadFavs();
+  box.innerHTML="";
+  if(!list.length){box.classList.remove("show");return;}
+  list.forEach(function(it,idx){
+    var row=document.createElement("div");
+    row.className="rrow";
+    var name=document.createElement("span");
+    name.className="fname";
+    name.textContent=it.name||(Number(it.lat).toFixed(4)+","+Number(it.lng).toFixed(4));
+    name.addEventListener("click",function(){
+      $("results").classList.remove("show");
+      applyFavorite(it);
+    });
+    var del=document.createElement("button");
+    del.className="fdel";
+    del.type="button";
+    del.textContent="删";
+    del.addEventListener("click",function(e){
+      e.stopPropagation();
+      var next=loadFavs();
+      next.splice(idx,1);
+      saveFavs(next);
+      if(next.length)renderFavs();else{box.innerHTML="";box.classList.remove("show");}
+      toast("已删除收藏");
+    });
+    row.appendChild(name);
+    row.appendChild(del);
+    box.appendChild(row);
+  });
+  box.classList.add("show");
+}
+function addFavorite(){
+  if(!Number.isFinite(WGS.lat)||!Number.isFinite(WGS.lng)){toast("当前坐标无效");return;}
+  var def=$("q").value.trim()||(WGS.lat.toFixed(4)+","+WGS.lng.toFixed(4));
+  var name=window.prompt("收藏名称",def);
+  if(name===null)return;
+  name=String(name).trim()||def;
+  var list=loadFavs().filter(function(it){
+    return Math.abs(Number(it.lat)-WGS.lat)>1e-5||Math.abs(Number(it.lng)-WGS.lng)>1e-5;
+  });
+  list.unshift({
+    name:name,
+    lat:WGS.lat,
+    lng:WGS.lng,
+    alt:numOrNull("alt"),
+    hacc:numOrNull("hacc"),
+    vacc:numOrNull("vacc"),
+    ts:Date.now()
+  });
+  saveFavs(list);
+  renderFavs();
+  toast("已收藏");
+}
+function toggleFavs(){
+  var box=$("favs");
+  if(box.classList.contains("show")){box.classList.remove("show");return;}
+  $("results").classList.remove("show");
+  if(!loadFavs().length){toast("暂无收藏");return;}
+  renderFavs();
 }
 
 function info(){
@@ -276,6 +371,8 @@ $("q").addEventListener("keydown",function(e){if(e.key==="Enter")search();});
 $("locatebtn").addEventListener("click",locateCurrent);
 $("savebtn").addEventListener("click",commit);
 $("restorebtn").addEventListener("click",toggleEnabled);
+$("favadd").addEventListener("click",addFavorite);
+$("favlistbtn").addEventListener("click",toggleFavs);
 load();
 </script>
 </body>

--- a/location-picker/server.js
+++ b/location-picker/server.js
@@ -233,9 +233,11 @@ const PAGE = `<!doctype html>
   .bar button:disabled{opacity:.55}
   .results{margin:0 8px;border:1px solid #e2e2e2;border-radius:8px;max-height:34vh;overflow:auto;display:none}
   .results.show{display:block}
-  .rrow{padding:10px 12px;font-size:14px;border-bottom:1px solid #eee;color:#222}
+  .rrow{padding:10px 12px;font-size:14px;border-bottom:1px solid #eee;color:#222;display:flex;align-items:center;gap:8px}
   .rrow:last-child{border-bottom:0}
   .rrow:active{background:#f0f6ff}
+  .rrow .fname{flex:1;min-width:0}
+  .rrow .fdel{padding:6px 10px;font-size:13px;border:0;border-radius:6px;background:#ff3b30;color:#fff;flex-shrink:0}
   #map{height:52vh}
   #info{padding:8px 10px;font-size:13px;line-height:1.4}
   .opts{padding:6px 10px 12px;display:flex;flex-wrap:wrap;gap:8px;align-items:flex-end}
@@ -243,6 +245,7 @@ const PAGE = `<!doctype html>
   .opts input{width:88px;padding:8px;font-size:15px;border:1px solid #ccc;border-radius:6px;margin-top:2px}
   #savebtn{padding:11px 20px;font-size:16px;border:0;border-radius:8px;background:#34c759;color:#fff;font-weight:600}
   #restorebtn{padding:11px 16px;font-size:15px;border:0;border-radius:8px;background:#8e8e93;color:#fff}
+  #favadd,#favlistbtn{padding:11px 14px;font-size:15px;border:0;border-radius:8px;background:#5856d6;color:#fff}
   .toast{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);
     background:rgba(0,0,0,.85);color:#fff;padding:10px 16px;border-radius:8px;
     font-size:14px;opacity:0;transition:opacity .3s;pointer-events:none;z-index:9999}
@@ -264,7 +267,10 @@ const PAGE = `<!doctype html>
   <label>垂直精度<input id="vacc" type="number" inputmode="numeric"></label>
   <button id="savebtn">保存定位</button>
   <button id="restorebtn">恢复真实定位</button>
+  <button id="favadd">收藏此点</button>
+  <button id="favlistbtn">我的收藏</button>
 </div>
+<div class="results" id="favs"></div>
 <div class="toast" id="toast"></div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
@@ -326,6 +332,95 @@ function geolocationErrorMessage(err){
   if(err&&err.code===2)return "暂时无法获取当前位置";
   if(err&&err.code===3)return "获取当前位置超时，请到开阔处重试";
   return "获取当前位置失败";
+}
+
+var FAV_KEY="lp_favs_v1";
+var FAV_MAX=12;
+function loadFavs(){
+  try{
+    var raw=localStorage.getItem(FAV_KEY);
+    var a=raw?JSON.parse(raw):[];
+    return Array.isArray(a)?a:[];
+  }catch(e){return [];}
+}
+function saveFavs(list){
+  try{localStorage.setItem(FAV_KEY,JSON.stringify(list.slice(0,FAV_MAX)));}catch(e){}
+}
+function applyFavorite(it){
+  var lat=Number(it.lat), lng=wrapLng(it.lng);
+  if(!Number.isFinite(lat)||!Number.isFinite(lng)){toast("收藏坐标无效");return;}
+  WGS={lat:lat,lng:lng};
+  saved=false;
+  if(it.alt!=null&&it.alt!=="")$("alt").value=it.alt;
+  if(it.hacc!=null&&it.hacc!=="")$("hacc").value=it.hacc;
+  if(it.vacc!=null&&it.vacc!=="")$("vacc").value=it.vacc;
+  var p=dispPos();
+  marker.setLatLng(p);
+  map.setView(p,15);
+  info();
+  toast("已加载收藏，确认后保存");
+}
+function renderFavs(){
+  var box=$("favs");
+  var list=loadFavs();
+  box.innerHTML="";
+  if(!list.length){box.classList.remove("show");return;}
+  list.forEach(function(it,idx){
+    var row=document.createElement("div");
+    row.className="rrow";
+    var name=document.createElement("span");
+    name.className="fname";
+    name.textContent=it.name||(Number(it.lat).toFixed(4)+","+Number(it.lng).toFixed(4));
+    name.addEventListener("click",function(){
+      $("results").classList.remove("show");
+      applyFavorite(it);
+    });
+    var del=document.createElement("button");
+    del.className="fdel";
+    del.type="button";
+    del.textContent="删";
+    del.addEventListener("click",function(e){
+      e.stopPropagation();
+      var next=loadFavs();
+      next.splice(idx,1);
+      saveFavs(next);
+      if(next.length)renderFavs();else{box.innerHTML="";box.classList.remove("show");}
+      toast("已删除收藏");
+    });
+    row.appendChild(name);
+    row.appendChild(del);
+    box.appendChild(row);
+  });
+  box.classList.add("show");
+}
+function addFavorite(){
+  if(!Number.isFinite(WGS.lat)||!Number.isFinite(WGS.lng)){toast("当前坐标无效");return;}
+  var def=$("q").value.trim()||(WGS.lat.toFixed(4)+","+WGS.lng.toFixed(4));
+  var name=window.prompt("收藏名称",def);
+  if(name===null)return;
+  name=String(name).trim()||def;
+  var list=loadFavs().filter(function(it){
+    return Math.abs(Number(it.lat)-WGS.lat)>1e-5||Math.abs(Number(it.lng)-WGS.lng)>1e-5;
+  });
+  list.unshift({
+    name:name,
+    lat:WGS.lat,
+    lng:WGS.lng,
+    alt:numOrNull("alt"),
+    hacc:numOrNull("hacc"),
+    vacc:numOrNull("vacc"),
+    ts:Date.now()
+  });
+  saveFavs(list);
+  renderFavs();
+  toast("已收藏");
+}
+function toggleFavs(){
+  var box=$("favs");
+  if(box.classList.contains("show")){box.classList.remove("show");return;}
+  $("results").classList.remove("show");
+  if(!loadFavs().length){toast("暂无收藏");return;}
+  renderFavs();
 }
 
 function info(){
@@ -497,6 +592,8 @@ $("q").addEventListener("keydown",function(e){if(e.key==="Enter")search();});
 $("locatebtn").addEventListener("click",locateCurrent);
 $("savebtn").addEventListener("click",commit);
 $("restorebtn").addEventListener("click",toggleEnabled);
+$("favadd").addEventListener("click",addFavorite);
+$("favlistbtn").addEventListener("click",toggleFavs);
 load();
 </script>
 </body>

--- a/location-picker/worker/src/page.js
+++ b/location-picker/worker/src/page.js
@@ -14,9 +14,11 @@ export const PAGE = `<!doctype html>
   .bar button:disabled{opacity:.55}
   .results{margin:0 8px;border:1px solid #e2e2e2;border-radius:8px;max-height:34vh;overflow:auto;display:none}
   .results.show{display:block}
-  .rrow{padding:10px 12px;font-size:14px;border-bottom:1px solid #eee;color:#222}
+  .rrow{padding:10px 12px;font-size:14px;border-bottom:1px solid #eee;color:#222;display:flex;align-items:center;gap:8px}
   .rrow:last-child{border-bottom:0}
   .rrow:active{background:#f0f6ff}
+  .rrow .fname{flex:1;min-width:0}
+  .rrow .fdel{padding:6px 10px;font-size:13px;border:0;border-radius:6px;background:#ff3b30;color:#fff;flex-shrink:0}
   #map{height:52vh}
   #info{padding:8px 10px;font-size:13px;line-height:1.4}
   .opts{padding:6px 10px 12px;display:flex;flex-wrap:wrap;gap:8px;align-items:flex-end}
@@ -24,6 +26,7 @@ export const PAGE = `<!doctype html>
   .opts input{width:88px;padding:8px;font-size:15px;border:1px solid #ccc;border-radius:6px;margin-top:2px}
   #savebtn{padding:11px 20px;font-size:16px;border:0;border-radius:8px;background:#34c759;color:#fff;font-weight:600}
   #restorebtn{padding:11px 16px;font-size:15px;border:0;border-radius:8px;background:#8e8e93;color:#fff}
+  #favadd,#favlistbtn{padding:11px 14px;font-size:15px;border:0;border-radius:8px;background:#5856d6;color:#fff}
   .toast{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);
     background:rgba(0,0,0,.85);color:#fff;padding:10px 16px;border-radius:8px;
     font-size:14px;opacity:0;transition:opacity .3s;pointer-events:none;z-index:9999}
@@ -45,7 +48,10 @@ export const PAGE = `<!doctype html>
   <label>垂直精度<input id="vacc" type="number" inputmode="numeric"></label>
   <button id="savebtn">保存定位</button>
   <button id="restorebtn">恢复真实定位</button>
+  <button id="favadd">收藏此点</button>
+  <button id="favlistbtn">我的收藏</button>
 </div>
+<div class="results" id="favs"></div>
 <div class="toast" id="toast"></div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script>
 <script>
@@ -106,6 +112,95 @@ function geolocationErrorMessage(err){
   if(err&&err.code===2)return "暂时无法获取当前位置";
   if(err&&err.code===3)return "获取当前位置超时，请到开阔处重试";
   return "获取当前位置失败";
+}
+
+var FAV_KEY="lp_favs_v1";
+var FAV_MAX=12;
+function loadFavs(){
+  try{
+    var raw=localStorage.getItem(FAV_KEY);
+    var a=raw?JSON.parse(raw):[];
+    return Array.isArray(a)?a:[];
+  }catch(e){return [];}
+}
+function saveFavs(list){
+  try{localStorage.setItem(FAV_KEY,JSON.stringify(list.slice(0,FAV_MAX)));}catch(e){}
+}
+function applyFavorite(it){
+  var lat=Number(it.lat), lng=wrapLng(it.lng);
+  if(!Number.isFinite(lat)||!Number.isFinite(lng)){toast("收藏坐标无效");return;}
+  WGS={lat:lat,lng:lng};
+  saved=false;
+  if(it.alt!=null&&it.alt!=="")$("alt").value=it.alt;
+  if(it.hacc!=null&&it.hacc!=="")$("hacc").value=it.hacc;
+  if(it.vacc!=null&&it.vacc!=="")$("vacc").value=it.vacc;
+  var p=dispPos();
+  marker.setLatLng(p);
+  map.setView(p,15);
+  info();
+  toast("已加载收藏，确认后保存");
+}
+function renderFavs(){
+  var box=$("favs");
+  var list=loadFavs();
+  box.innerHTML="";
+  if(!list.length){box.classList.remove("show");return;}
+  list.forEach(function(it,idx){
+    var row=document.createElement("div");
+    row.className="rrow";
+    var name=document.createElement("span");
+    name.className="fname";
+    name.textContent=it.name||(Number(it.lat).toFixed(4)+","+Number(it.lng).toFixed(4));
+    name.addEventListener("click",function(){
+      $("results").classList.remove("show");
+      applyFavorite(it);
+    });
+    var del=document.createElement("button");
+    del.className="fdel";
+    del.type="button";
+    del.textContent="删";
+    del.addEventListener("click",function(e){
+      e.stopPropagation();
+      var next=loadFavs();
+      next.splice(idx,1);
+      saveFavs(next);
+      if(next.length)renderFavs();else{box.innerHTML="";box.classList.remove("show");}
+      toast("已删除收藏");
+    });
+    row.appendChild(name);
+    row.appendChild(del);
+    box.appendChild(row);
+  });
+  box.classList.add("show");
+}
+function addFavorite(){
+  if(!Number.isFinite(WGS.lat)||!Number.isFinite(WGS.lng)){toast("当前坐标无效");return;}
+  var def=$("q").value.trim()||(WGS.lat.toFixed(4)+","+WGS.lng.toFixed(4));
+  var name=window.prompt("收藏名称",def);
+  if(name===null)return;
+  name=String(name).trim()||def;
+  var list=loadFavs().filter(function(it){
+    return Math.abs(Number(it.lat)-WGS.lat)>1e-5||Math.abs(Number(it.lng)-WGS.lng)>1e-5;
+  });
+  list.unshift({
+    name:name,
+    lat:WGS.lat,
+    lng:WGS.lng,
+    alt:numOrNull("alt"),
+    hacc:numOrNull("hacc"),
+    vacc:numOrNull("vacc"),
+    ts:Date.now()
+  });
+  saveFavs(list);
+  renderFavs();
+  toast("已收藏");
+}
+function toggleFavs(){
+  var box=$("favs");
+  if(box.classList.contains("show")){box.classList.remove("show");return;}
+  $("results").classList.remove("show");
+  if(!loadFavs().length){toast("暂无收藏");return;}
+  renderFavs();
 }
 
 function info(){
@@ -273,6 +368,8 @@ $("q").addEventListener("keydown",function(e){if(e.key==="Enter")search();});
 $("locatebtn").addEventListener("click",locateCurrent);
 $("savebtn").addEventListener("click",commit);
 $("restorebtn").addEventListener("click",toggleEnabled);
+$("favadd").addEventListener("click",addFavorite);
+$("favlistbtn").addEventListener("click",toggleFavs);
 load();
 </script>
 </body>

--- a/location-picker/worker/test/favorites-and-loon.test.mjs
+++ b/location-picker/worker/test/favorites-and-loon.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const sourcePath = new URL("../src/page.js", import.meta.url);
+const webuiPath = new URL("../../cloudflare-webui/worker.js", import.meta.url);
+const serverPath = new URL("../../server.js", import.meta.url);
+const loonPath = new URL("../../../ios-location-spoofer.lnplugin", import.meta.url);
+
+const pages = [
+  ["source page", await readFile(sourcePath, "utf8")],
+  ["webui artifact", await readFile(webuiPath, "utf8")],
+  ["node server page", await readFile(serverPath, "utf8")],
+];
+
+for (const [label, content] of pages) {
+  test(`${label} exposes favorite controls`, () => {
+    assert.match(content, /id="favadd"/);
+    assert.match(content, /id="favlistbtn"/);
+    assert.match(content, /function addFavorite\(\)/);
+    assert.match(content, /function applyFavorite\(/);
+    assert.match(content, /localStorage\.getItem\(FAV_KEY\)/);
+    assert.match(content, /FAV_MAX\s*=\s*12/);
+  });
+
+  test(`${label} loads favorite pin without auto-save`, () => {
+    assert.match(content, /function applyFavorite\(it\)\{[\s\S]*?saved\s*=\s*false;[\s\S]*?toast\("已加载收藏，确认后保存"\);\s*\}/);
+    assert.doesNotMatch(content, /function applyFavorite\(it\)\{[\s\S]*?commit\(\);[\s\S]*?\}/);
+  });
+}
+
+test("Loon plugin exposes editable accuracy arguments", async () => {
+  const content = await readFile(loonPath, "utf8");
+  assert.match(content, /horizontalAccuracy\s*=\s*input,"39"/);
+  assert.match(content, /verticalAccuracy\s*=\s*input,"1000"/);
+  assert.match(
+    content,
+    /argument=\[\{enabled\},\{latitude\},\{longitude\},\{altitude\},\{horizontalAccuracy\},\{verticalAccuracy\},\{address\},\{configHost\},\{configToken\},\{configUrl\},\{debug\}\]/,
+  );
+  assert.match(content, /script-path=https:\/\/raw\.githubusercontent\.com\/mekos2772\/ios-location-spoofer\/main\/location-spoofer\.js/);
+});


### PR DESCRIPTION
## Summary
Closes #24, #27, #32.

### Favorites (#24 / #27)
- Add **收藏此点** / **我的收藏** on Worker, Cloudflare WebUI, and Node server picker pages
- Stored in browser localStorage (max 12), includes lat/lng/alt/accuracy
- Loading a favorite only moves the pin; does not auto-save

### Loon accuracy (#32)
- Expose editable horizontalAccuracy / verticalAccuracy in Loon plugin UI
- Pass them through the response script argument=
- With remote configUrl / loc.json, web picker values still take precedence

Also points Loon script-path / homepage to mekos2772 main.

## Test plan
- [x] node --test location-picker/worker/test/*.test.mjs (19 pass)
- [x] node --check on page.js / worker.js / server.js