### PR TITLE
fix: support iOS 12 JavaScriptCore without BigInt

### DIFF
--- a/ios-location-spoofer-ios12.sgmodule
+++ b/ios-location-spoofer-ios12.sgmodule
@@ -1,0 +1,9 @@
+#!name=iOS Location Spoofer (iOS 12)
+#!desc=iOS 12 compatible WLOC response rewriter. Replace https://raw.githubusercontent.com/Halilo-muso/ios-location-spoofer/ios12-compat/location-spoofer.js before importing.
+#!homepage=https://github.com/mekos2772/ios-location-spoofer
+
+[Script]
+iOS Location Spoofer iOS 12 = type=http-response,pattern=^https?:\/\/(?:gs-loc(?:-cn)?\.apple\.com|gsp-ssl\.ls\.apple\.com|bluedot\.is\.autonavi\.com(?:\.gds\.alibabadns\.com)?)\/clls\/wloc(?:\?.*)?$,requires-body=1,binary-body-mode=1,max-size=1048576,timeout=10,script-path=https://raw.githubusercontent.com/Halilo-muso/ios-location-spoofer/ios12-compat/location-spoofer.js,argument=mode=response&latitude=37.3349&longitude=-122.00902&horizontalAccuracy=39&verticalAccuracy=1000&altitude=530&debug=true
+
+[MITM]
+hostname = %APPEND% gs-loc.apple.com, gs-loc-cn.apple.com, gsp-ssl.ls.apple.com, bluedot.is.autonavi.com, bluedot.is.autonavi.com.gds.alibabadns.com

--- a/location-spoofer.js
+++ b/location-spoofer.js
@@ -1,4 +1,7 @@
 /*
+ * iOS 12 compatibility build. The protobuf int64 implementation deliberately
+ * avoids BigInt syntax so JavaScriptCore on iOS 12 can parse this file.
+ *
  * 拦截 Apple /clls/wloc 接口的回应，解 ARPC 封包，改 WiFi 热点和基站坐标，
  * 再按 Apple 的格式封回去返回给系统。
  *
@@ -238,52 +241,127 @@
     return out;
   }
 
-  function encodeVarintUnsigned(value) {
-    var v = typeof value === "bigint" ? value : BigInt(value);
-    if (v < 0n) {
-      throw new Error("negative unsigned varint");
+  // iOS 12 JavaScriptCore cannot parse BigInt literals. Represent uint64 values
+  // as unsigned high/low 32-bit words so negative coordinates still use the
+  // canonical 10-byte protobuf int64 encoding.
+  var UINT32_BASE = 4294967296;
+  var MAX_SAFE_INTEGER = 9007199254740991;
+
+  function uint64FromUnsignedNumber(value) {
+    var number = Number(value);
+    if (!Number.isFinite(number) || number < 0 || Math.floor(number) !== number || number > MAX_SAFE_INTEGER) {
+      throw new Error("invalid unsigned varint value: " + value);
+    }
+    return {
+      low: number >>> 0,
+      high: Math.floor(number / UINT32_BASE) >>> 0
+    };
+  }
+
+  function uint64FromSignedNumber(value) {
+    var number = Math.trunc(Number(value));
+    if (!Number.isFinite(number) || Math.abs(number) > MAX_SAFE_INTEGER) {
+      throw new Error("invalid signed int64 value: " + value);
+    }
+    if (number >= 0) {
+      return uint64FromUnsignedNumber(number);
     }
 
-    var out = [];
-    while (v >= 0x80n) {
-      out.push(Number((v & 0x7fn) | 0x80n));
-      v >>= 7n;
+    var magnitude = uint64FromUnsignedNumber(-number);
+    var low = (~magnitude.low + 1) >>> 0;
+    var carry = low === 0 ? 1 : 0;
+    return {
+      low: low,
+      high: (~magnitude.high + carry) >>> 0
+    };
+  }
+
+  function uint64ToSafeNumber(words) {
+    var value = (words.high >>> 0) * UINT32_BASE + (words.low >>> 0);
+    if (value > MAX_SAFE_INTEGER) {
+      throw new Error("uint64 exceeds safe integer range");
     }
-    out.push(Number(v));
+    return value;
+  }
+
+  function uint64ToSignedNumber(words) {
+    var low = words.low >>> 0;
+    var high = words.high >>> 0;
+    if ((high & 0x80000000) === 0) {
+      return uint64ToSafeNumber({ low: low, high: high });
+    }
+
+    var magnitudeLow = (~low + 1) >>> 0;
+    var carry = magnitudeLow === 0 ? 1 : 0;
+    var magnitudeHigh = (~high + carry) >>> 0;
+    var magnitude = magnitudeHigh * UINT32_BASE + magnitudeLow;
+    if (magnitude > MAX_SAFE_INTEGER) {
+      throw new Error("int64 exceeds safe integer range");
+    }
+    return -magnitude;
+  }
+
+  function encodeVarintWords(words) {
+    var low = words.low >>> 0;
+    var high = words.high >>> 0;
+    var out = [];
+
+    while (high !== 0 || low >= 0x80) {
+      out.push((low & 0x7f) | 0x80);
+      low = ((low >>> 7) | (high << 25)) >>> 0;
+      high = high >>> 7;
+    }
+    out.push(low & 0x7f);
     return bytesFromArray(out);
   }
 
+  function encodeVarintUnsigned(value) {
+    return encodeVarintWords(uint64FromUnsignedNumber(value));
+  }
+
   function encodeVarintSignedInt64(value) {
-    var v = typeof value === "bigint" ? value : BigInt(Math.trunc(value));
-    if (v < 0n) {
-      v = BigInt.asUintN(64, v);
-    }
-    return encodeVarintUnsigned(v);
+    return encodeVarintWords(uint64FromSignedNumber(value));
   }
 
   function decodeVarint(bytes, offset) {
-    var result = 0n;
-    var shift = 0n;
+    var low = 0;
+    var high = 0;
+    var shift = 0;
     var current = offset;
+    var count = 0;
 
-    while (current < bytes.length) {
+    while (current < bytes.length && count < 10) {
       var b = bytes[current];
+      var payload = b & 0x7f;
       current += 1;
-      result |= BigInt(b & 0x7f) << shift;
+      count += 1;
+
+      if (shift < 32) {
+        low = (low | ((payload << shift) >>> 0)) >>> 0;
+        if (shift > 25) {
+          high = (high | (payload >>> (32 - shift))) >>> 0;
+        }
+      } else {
+        if (shift === 63 && payload > 1) {
+          throw new Error("varint exceeds uint64 range");
+        }
+        high = (high | ((payload << (shift - 32)) >>> 0)) >>> 0;
+      }
+
       if ((b & 0x80) === 0) {
-        return { value: result, offset: current };
+        return { low: low, high: high, offset: current };
       }
-      shift += 7n;
-      if (shift > 70n) {
-        throw new Error("varint too long");
-      }
+      shift += 7;
     }
 
+    if (count >= 10) {
+      throw new Error("varint too long");
+    }
     throw new Error("unterminated varint");
   }
 
   function makeKey(fieldNumber, wireType) {
-    return encodeVarintUnsigned((BigInt(fieldNumber) << 3n) | BigInt(wireType));
+    return encodeVarintUnsigned(fieldNumber * 8 + wireType);
   }
 
   function makeVarintField(fieldNumber, value) {
@@ -303,8 +381,9 @@
       var key = decodeVarint(bytes, offset);
       offset = key.offset;
 
-      var fieldNumber = Number(key.value >> 3n);
-      var wireType = Number(key.value & 0x7n);
+      var keyValue = uint64ToSafeNumber(key);
+      var fieldNumber = Math.floor(keyValue / 8);
+      var wireType = keyValue & 0x7;
       if (fieldNumber === 0) {
         throw new Error("protobuf field number 0");
       }
@@ -317,7 +396,7 @@
         valueEnd = offset + 8;
       } else if (wireType === 2) {
         var lengthInfo = decodeVarint(bytes, offset);
-        var length = Number(lengthInfo.value);
+        var length = uint64ToSafeNumber(lengthInfo);
         valueStart = lengthInfo.offset;
         valueEnd = valueStart + length;
       } else if (wireType === 5) {
@@ -359,7 +438,7 @@
     if (!field || field.wireType !== 0) {
       return null;
     }
-    return BigInt.asIntN(64, decodeVarint(field.valueBytes, 0).value);
+    return uint64ToSignedNumber(decodeVarint(field.valueBytes, 0));
   }
 
   function locationSummary(locationPayload) {
@@ -370,7 +449,7 @@
       if (lat == null || lon == null) {
         return "<missing>";
       }
-      return (Number(lat) / 100000000).toFixed(8) + "," + (Number(lon) / 100000000).toFixed(8);
+      return (lat / 100000000).toFixed(8) + "," + (lon / 100000000).toFixed(8);
     } catch (err) {
       return "<parse-failed:" + err.message + ">";
     }

--- a/test-ios12-compat.js
+++ b/test-ios12-compat.js
@@ -1,0 +1,116 @@
+"use strict";
+
+var assert = require("assert");
+var api = require("./location-spoofer.js");
+
+function bytes(values) {
+  return Array.prototype.slice.call(values);
+}
+
+function oracleSignedVarint(value) {
+  var current = BigInt(value);
+  if (current < 0n) {
+    current = BigInt.asUintN(64, current);
+  }
+  var out = [];
+  while (current >= 0x80n) {
+    out.push(Number((current & 0x7fn) | 0x80n));
+    current >>= 7n;
+  }
+  out.push(Number(current));
+  return out;
+}
+
+function makeLocation(latitude, longitude) {
+  return api.concatBytes([
+    api.makeVarintField(1, api.coordToInt(latitude)),
+    api.makeVarintField(2, api.coordToInt(longitude)),
+    api.makeVarintField(3, 25),
+    api.makeVarintField(5, 15)
+  ]);
+}
+
+function makePayload(latitude, longitude) {
+  var location = makeLocation(latitude, longitude);
+  var wifi = api.concatBytes([
+    api.makeLengthDelimitedField(1, api.binaryStringToBytes("00:11:22:33:44:55")),
+    api.makeLengthDelimitedField(2, location)
+  ]);
+  var cell = api.makeLengthDelimitedField(5, location);
+  return api.concatBytes([
+    api.makeLengthDelimitedField(2, wifi),
+    api.makeLengthDelimitedField(22, cell)
+  ]);
+}
+
+function quantizedCoordinate(value) {
+  return (api.coordToInt(value) / 100000000).toFixed(8);
+}
+
+function expectedSummary(latitude, longitude) {
+  var pair = quantizedCoordinate(latitude) + "," + quantizedCoordinate(longitude);
+  return "firstWifi=" + pair + ", firstCell=" + pair;
+}
+
+[
+  0,
+  1,
+  127,
+  128,
+  4294967295,
+  4294967296,
+  18000000000,
+  -1,
+  -12200902000,
+  -18000000000
+].forEach(function (value) {
+  assert.deepStrictEqual(
+    bytes(api.encodeVarintSignedInt64(value)),
+    oracleSignedVarint(value),
+    "signed varint mismatch for " + value
+  );
+});
+
+var syntheticPayload = makePayload(22.544577, 113.94114);
+var syntheticResponse = api.buildAppleWLocResponse(syntheticPayload);
+var syntheticResult = api.spoofAppleResponse(syntheticResponse, {
+  latitude: 37.3349,
+  longitude: -122.00902,
+  horizontalAccuracy: 9,
+  verticalAccuracy: 20,
+  altitude: 15
+});
+
+assert.strictEqual(syntheticResult.kind, "synthetic");
+assert.strictEqual(syntheticResult.wifiCount, 1);
+assert.strictEqual(syntheticResult.cellCount, 1);
+assert.strictEqual(
+  api.patchedPayloadSummary(syntheticResult.payload),
+  expectedSummary(37.3349, -122.00902)
+);
+
+var arpcResponse = api.serializeArpc({
+  version: 1,
+  locale: "en_US",
+  appIdentifier: "com.apple.locationd",
+  osVersion: "12.5.8",
+  functionId: 1,
+  payload: makePayload(-33.8688, 151.2093)
+});
+var arpcResult = api.spoofAppleResponse(arpcResponse, {
+  latitude: -33.8688,
+  longitude: 151.2093,
+  horizontalAccuracy: 12,
+  verticalAccuracy: 20,
+  altitude: 40
+});
+
+assert.strictEqual(arpcResult.kind, "arpc");
+assert.strictEqual(arpcResult.wifiCount, 1);
+assert.strictEqual(arpcResult.cellCount, 1);
+assert.strictEqual(
+  api.patchedPayloadSummary(arpcResult.payload),
+  expectedSummary(-33.8688, 151.2093)
+);
+
+console.log("iOS 12 compatibility tests passed");


### PR DESCRIPTION
`location-spoofer.js` uses BigInt literals such as `0n`. JavaScriptCore on iOS 12 cannot parse this syntax, so Shadowrocket fails before the WLOC response can be rewritten.