### PR TITLE
fix(scripts): 最小改写，收敛为 iOS 27 beta5 及以下的稳定适配

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ iPhone 依靠周围的 Wi-Fi 和基站信号，把 BSSID / CellID 列表发给 A
 - **多平台** — 适配 Shadowrocket / Surge / Loon / Quantumult X / Stash 五个代理平台，免编译即导即用
 - **蜂窝基站坐标修改** — 不只改 Wi-Fi 热点坐标，还处理 CellTower（字段 22/24）的坐标替换
 - **多响应封装兼容 + 原始字节扫描兜底** — 自动识别 Apple 回应的封装格式（ARPC / synthetic / marker / bare）；当测试版系统改变封装导致已知格式解析失败时，直接在响应字节里定位并改写坐标，避免「放行原始数据 → 定位不生效」
-- **运动状态伪造** — 一并改写 motionActivityType / motionActivityConfidence，降低被系统识破的可能
+- **最小改写** — 只替换坐标（纬度 / 经度 / 精度），海拔、垂直精度、运动状态等字段一律透传 Apple 原值；不新增字段、不丢弃根字段，最大程度避免 iOS 把响应判为非法（否则会直接显示「定位不可用」）
 - **iOS 12 兼容构建** — `location-spoofer.js` 使用不含 BigInt 的 int64 实现，兼容旧款设备的 JavaScriptCore
 
 ---
@@ -123,12 +123,11 @@ latitude=39.9042&longitude=116.4074
 
 | 参数 | 默认值 | 说明 |
 |------|--------|------|
-| `latitude` | 37.3349 | 目标纬度 |
-| `longitude` | -122.00902 | 目标经度 |
+| `latitude` | 37.3349 | 目标纬度（始终改写） |
+| `longitude` | -122.00902 | 目标经度（始终改写） |
 | `address` | （空） | 地址搜索（Loon 插件 UI 填写，联网解析为经纬度，优先于手动经纬度） |
-| `horizontalAccuracy` | 39 | 水平精度（米），越小越像 GPS |
-| `verticalAccuracy` | 1000 | 垂直精度（米） |
-| `altitude` | 530 | 海拔（米），建议按目标地点改成真实海拔 |
+| `horizontalAccuracy` | 39 | 水平精度（米），仅当目标坐标字段里存在精度字段时替换 |
+| 海拔 / 垂直精度 / 运动状态等 | — | 不再由脚本改写，一律沿用 Apple 响应里的原值（最小改写，防止 iOS 校验失败） |
 | `failOpen` | true | 出错时放行原始数据（避免定位完全不可用） |
 | `debug` | false | 调试日志 |
 
@@ -219,7 +218,7 @@ docker compose up -d
 
 - **核心逻辑**：拦截 `/clls/wloc` 响应 → 解析封装（ARPC / synthetic / marker / bare）→ 替换 WiFi（字段 2）与基站（字段 22/24）下的 Location 子消息坐标 → 按原封装封回，iOS 才能正确识别
 - **健壮性**：当测试版系统改变响应封装、已知格式解析失败时，脚本自动启用**原始字节扫描兜底**，直接在返回字节中定位坐标子消息并改写，避免放行导致定位不生效
-- **定位精度**：默认 `horizontalAccuracy=39`，想更接近 GPS 可调小到 5~15；配了真实海拔后 `verticalAccuracy` 可调小到 10~30
+- **定位精度**：`horizontalAccuracy` 可在参数里设置（默认 39，想更接近 GPS 可调小到 5~15）。海拔、垂直精度等不再由脚本改写，沿用 Apple 响应原值，减小被系统识破 / 校验失败的风险
 - **仅网络定位**：GPS 信号强时系统可能忽略网络定位结果，Wi-Fi 定位为主的室内场景效果最佳
 
 ## 致谢

--- a/location-spoofer-qx.js
+++ b/location-spoofer-qx.js
@@ -21,9 +21,11 @@
 
   var APPLE_WLOC_PREFIX = new Uint8Array([0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00]);
   var APPLE_WLOC_MARKER = new Uint8Array([0x00, 0x00, 0x00, 0x01, 0x00, 0x00]);
-  var ROOT_DROP_FIELDS = { 3: true, 4: true, 33: true };
+  var ROOT_DROP_FIELDS = {};
   var CELL_RESPONSE_FIELDS = { 22: true, 24: true };
-  var LOCATION_REPLACED_FIELDS = { 1: true, 2: true, 3: true, 4: true, 5: true, 6: true, 11: true, 12: true };
+  // 位置子消息只改写 纬度(1)/经度(2)/精度(3)，其余字段原样透传——改写越多越容易被
+  // iOS 判定为非法响应，导致 “定位不可用”。
+  var LOCATION_REPLACED_FIELDS = { 1: true, 2: true, 3: true };
 
   // ========== Byte Utilities ==========
 
@@ -212,38 +214,41 @@
   function coordToInt(value) { return Math.trunc(Number(value) * 100000000); }
 
   function patchLocation(locationPayload, config) {
+    // 最小改写：只替换已存在的 纬度(1)/经度(2)/精度(3)；没有纬度+经度子消息原样放行。
     var parts = [], fields = locationPayload.length ? parseFields(locationPayload) : [];
-    for (var i = 0; i < fields.length; i++) { if (!LOCATION_REPLACED_FIELDS[fields[i].fieldNumber]) parts.push(fields[i].raw); }
-    parts.push(makeVarintField(1, coordToInt(config.latitude)));
-    parts.push(makeVarintField(2, coordToInt(config.longitude)));
-    parts.push(makeVarintField(3, config.horizontalAccuracy));
-    parts.push(makeVarintField(4, config.unknownValue4));
-    parts.push(makeVarintField(5, config.altitude));
-    parts.push(makeVarintField(6, config.verticalAccuracy));
-    parts.push(makeVarintField(11, config.motionActivityType));
-    parts.push(makeVarintField(12, config.motionActivityConfidence));
+    var hasLat = false, hasLon = false, i;
+    for (i = 0; i < fields.length; i++) {
+      if (fields[i].fieldNumber === 1 && fields[i].wireType === 0) hasLat = true;
+      if (fields[i].fieldNumber === 2 && fields[i].wireType === 0) hasLon = true;
+    }
+    if (!hasLat || !hasLon) return locationPayload;
+    for (i = 0; i < fields.length; i++) {
+      var field = fields[i];
+      if (field.fieldNumber === 1 && field.wireType === 0) parts.push(makeVarintField(1, coordToInt(config.latitude)));
+      else if (field.fieldNumber === 2 && field.wireType === 0) parts.push(makeVarintField(2, coordToInt(config.longitude)));
+      else if (field.fieldNumber === 3 && field.wireType === 0) parts.push(makeVarintField(3, config.horizontalAccuracy));
+      else parts.push(field.raw);
+    }
     return concatBytes(parts);
   }
 
   function patchWifiDevice(wifiPayload, config) {
-    var fields = parseFields(wifiPayload), parts = [], patchedLocation = false;
+    var fields = parseFields(wifiPayload), parts = [];
     for (var i = 0; i < fields.length; i++) {
       if (fields[i].fieldNumber === 2 && fields[i].wireType === 2) {
-        parts.push(makeLengthDelimitedField(2, patchLocation(fields[i].valueBytes, config))); patchedLocation = true;
+        parts.push(makeLengthDelimitedField(2, patchLocation(fields[i].valueBytes, config)));
       } else parts.push(fields[i].raw);
     }
-    if (!patchedLocation) parts.push(makeLengthDelimitedField(2, patchLocation(new Uint8Array([]), config)));
     return concatBytes(parts);
   }
 
   function patchCellTower(cellPayload, config) {
-    var fields = parseFields(cellPayload), parts = [], patchedLocation = false;
+    var fields = parseFields(cellPayload), parts = [];
     for (var i = 0; i < fields.length; i++) {
       if (fields[i].fieldNumber === 5 && fields[i].wireType === 2) {
-        parts.push(makeLengthDelimitedField(5, patchLocation(fields[i].valueBytes, config))); patchedLocation = true;
+        parts.push(makeLengthDelimitedField(5, patchLocation(fields[i].valueBytes, config)));
       } else parts.push(fields[i].raw);
     }
-    if (!patchedLocation) parts.push(makeLengthDelimitedField(5, patchLocation(new Uint8Array([]), config)));
     return concatBytes(parts);
   }
 
@@ -253,7 +258,7 @@
       var field = fields[i];
       if (field.fieldNumber === 2 && field.wireType === 2) { parts.push(makeLengthDelimitedField(2, patchWifiDevice(field.valueBytes, config))); wifiCount += 1; }
       else if (isCellResponseField(field.fieldNumber) && field.wireType === 2) { parts.push(makeLengthDelimitedField(field.fieldNumber, patchCellTower(field.valueBytes, config))); cellCount += 1; }
-      else if (!ROOT_DROP_FIELDS[field.fieldNumber]) parts.push(field.raw);
+      else parts.push(field.raw);
     }
     return { payload: concatBytes(parts), wifiCount: wifiCount, cellCount: cellCount };
   }

--- a/location-spoofer.js
+++ b/location-spoofer.js
@@ -38,18 +38,12 @@
   // Stable marker that precedes the AppleWLoc protobuf inside a REAL Apple /clls/wloc
   // response. After the marker come 2 bytes (uint16 BE payload length) then the payload.
   var APPLE_WLOC_MARKER = bytesFromArray([0x00, 0x00, 0x00, 0x01, 0x00, 0x00]);
-  var ROOT_DROP_FIELDS = { 3: true, 4: true, 33: true };
+  var ROOT_DROP_FIELDS = {};
   var CELL_RESPONSE_FIELDS = { 22: true, 24: true };
-  var LOCATION_REPLACED_FIELDS = {
-    1: true,
-    2: true,
-    3: true,
-    4: true,
-    5: true,
-    6: true,
-    11: true,
-    12: true
-  };
+  // 位置子消息只改写 纬度(1)/经度(2)/精度(3)，其余字段（海拔、垂直精度、
+  // 运动状态、unknown 等）一律原样透传——改写或新增的字段越多，越容易被
+  // iOS 判定为非法响应，导致 “定位不可用”。
+  var LOCATION_REPLACED_FIELDS = { 1: true, 2: true, 3: true };
 
   function bytesFromArray(values) {
     return new Uint8Array(values);
@@ -554,42 +548,47 @@
   }
 
   function patchLocation(locationPayload, config) {
+    // 最小改写：只替换已存在的 纬度(1)/经度(2)/精度(3)，不改动、不新增任何其他字段。
+    // 若该位置子消息连纬度或经度都没有（不是我们要的目标），原样放行，避免塞数据
+    // 把响应写坏导致 iOS “定位不可用”。
     var parts = [];
     var fields = locationPayload.length ? parseFields(locationPayload) : [];
-    for (var i = 0; i < fields.length; i += 1) {
-      if (!LOCATION_REPLACED_FIELDS[fields[i].fieldNumber]) {
-        parts.push(fields[i].raw);
+    var hasLat = false;
+    var hasLon = false;
+    var i;
+    for (i = 0; i < fields.length; i += 1) {
+      if (fields[i].fieldNumber === 1 && fields[i].wireType === 0) hasLat = true;
+      if (fields[i].fieldNumber === 2 && fields[i].wireType === 0) hasLon = true;
+    }
+    if (!hasLat || !hasLon) {
+      return locationPayload;
+    }
+    for (i = 0; i < fields.length; i += 1) {
+      var field = fields[i];
+      if (field.fieldNumber === 1 && field.wireType === 0) {
+        parts.push(makeVarintField(1, coordToInt(config.latitude)));
+      } else if (field.fieldNumber === 2 && field.wireType === 0) {
+        parts.push(makeVarintField(2, coordToInt(config.longitude)));
+      } else if (field.fieldNumber === 3 && field.wireType === 0) {
+        parts.push(makeVarintField(3, config.horizontalAccuracy));
+      } else {
+        parts.push(field.raw);
       }
     }
-
-    parts.push(makeVarintField(1, coordToInt(config.latitude)));
-    parts.push(makeVarintField(2, coordToInt(config.longitude)));
-    parts.push(makeVarintField(3, config.horizontalAccuracy));
-    parts.push(makeVarintField(4, config.unknownValue4));
-    parts.push(makeVarintField(5, config.altitude));
-    parts.push(makeVarintField(6, config.verticalAccuracy));
-    parts.push(makeVarintField(11, config.motionActivityType));
-    parts.push(makeVarintField(12, config.motionActivityConfidence));
     return concatBytes(parts);
   }
 
   function patchWifiDevice(wifiPayload, config) {
     var fields = parseFields(wifiPayload);
     var parts = [];
-    var patchedLocation = false;
 
     for (var i = 0; i < fields.length; i += 1) {
       var field = fields[i];
       if (field.fieldNumber === 2 && field.wireType === 2) {
         parts.push(makeLengthDelimitedField(2, patchLocation(field.valueBytes, config)));
-        patchedLocation = true;
       } else {
         parts.push(field.raw);
       }
-    }
-
-    if (!patchedLocation) {
-      parts.push(makeLengthDelimitedField(2, patchLocation(bytesFromArray([]), config)));
     }
 
     return concatBytes(parts);
@@ -598,20 +597,14 @@
   function patchCellTower(cellPayload, config) {
     var fields = parseFields(cellPayload);
     var parts = [];
-    var patchedLocation = false;
 
     for (var i = 0; i < fields.length; i += 1) {
       var field = fields[i];
       if (field.fieldNumber === 5 && field.wireType === 2) {
         parts.push(makeLengthDelimitedField(5, patchLocation(field.valueBytes, config)));
-        patchedLocation = true;
       } else {
         parts.push(field.raw);
       }
-    }
-
-    if (!patchedLocation) {
-      parts.push(makeLengthDelimitedField(5, patchLocation(bytesFromArray([]), config)));
     }
 
     return concatBytes(parts);
@@ -631,7 +624,8 @@
       } else if (isCellResponseField(field.fieldNumber) && field.wireType === 2) {
         parts.push(makeLengthDelimitedField(field.fieldNumber, patchCellTower(field.valueBytes, config)));
         cellCount += 1;
-      } else if (!ROOT_DROP_FIELDS[field.fieldNumber]) {
+      } else {
+        // 根级其余字段一律原样保留，避免丢弃 iOS 校验所依赖的信息
         parts.push(field.raw);
       }
     }


### PR DESCRIPTION
将 main 收敛为 iOS 27 beta5 及以下的稳定适配（以 5 域名 MITM + 最小改写脚本为基准）：

- 脚本改为最小改写：只替换 纬度(1)/经度(2)/精度(3)，其余字段透传 Apple 原值，不新增字段、不丢根字段
- MITM 保持 beta5 的 5 域名集合（不做 beta6 的 gspe* ls.apple.com 扩展——beta6 该池实测握手即断、证书固定，扩展反而导致“加载不出定位”）
- 说明：iOS 27 beta6 因苹果对定位主机启用证书固定，MITM 类 WLOC 伪造暂不可行，社区亦无解